### PR TITLE
Add support for destructuring lambda fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
+### Added
+ - Add support for destructuring referential tuple lambda fixtures (e.g. `x, y, z = lambda_fixture('a', 'b', 'c')`)
+ - Add support for destructuring parametrized lambda fixtures (e.g. `a, b, c = lambda_fixture(params=[pytest.param('ayy', 'bee', 'see')])`)
 
 
 ## [1.3.0] — 2022-05-17

--- a/pytest_lambda/plugin.py
+++ b/pytest_lambda/plugin.py
@@ -1,9 +1,11 @@
 import inspect
-from typing import List, Tuple
+from typing import List, Sequence, Set, Tuple
 
-from _pytest.python import Module
+import pytest
+from _pytest.mark import Mark, ParameterSet
+from _pytest.python import Metafunc, Module
 
-from pytest_lambda.impl import LambdaFixture
+from pytest_lambda.impl import LambdaFixture, _LambdaFixtureParametrizedIterator
 
 
 def pytest_collectstart(collector):
@@ -26,3 +28,54 @@ def process_lambda_fixtures(parent):
         attr.contribute_to_parent(parent, name)
 
     return parent
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_generate_tests(metafunc: Metafunc) -> None:
+    """Parametrize all tests using destructured parametrized lambda fixtures
+
+    This is what powers things like:
+
+        a, b, c = lambda_fixture(params=[
+            pytest.param(1, 2, 3)
+        ])
+
+        def test_my_thing(a, b, c):
+            assert a < b < c
+
+    """
+    param_sources: Set[LambdaFixture] = set()
+
+    for argname in metafunc.fixturenames:
+        # Get the FixtureDefs for the argname.
+        fixture_defs = metafunc._arg2fixturedefs.get(argname)
+        if not fixture_defs:
+            # Will raise FixtureLookupError at setup time if not parametrized somewhere
+            # else (e.g @pytest.mark.parametrize)
+            continue
+
+        for fixturedef in reversed(fixture_defs):
+            param_source = getattr(fixturedef.func, '_self_params_source', None)
+            if param_source:
+                param_sources.add(param_source)
+
+    if param_sources:
+        requested_fixturenames = set(metafunc.fixturenames)
+
+        for param_source in param_sources:
+            params_iter = param_source._self_iter
+            assert isinstance(params_iter, _LambdaFixtureParametrizedIterator)
+
+            # TODO(zk): skip parametrization for args already parametrized by @mark.parametrize
+            # XXX(zk): is there a way around falsifying the requested fixturenames to avoid "uses no argument" error?
+            for child_name in params_iter.child_names:
+                if child_name not in requested_fixturenames:
+                    metafunc.fixturenames.append(child_name)
+                    requested_fixturenames.add(child_name)
+
+            metafunc.parametrize(
+                params_iter.child_names,
+                param_source.fixture_kwargs['params'],
+                scope=param_source.fixture_kwargs.get('scope'),
+                ids=param_source.fixture_kwargs.get('ids'),
+            )

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -1,3 +1,5 @@
+import pytest
+
 from pytest_lambda import lambda_fixture, static_fixture
 
 
@@ -38,6 +40,35 @@ def it_processes_toplevel_tuple_lambda_fixture(abc):
     expected = ('a', 'b', 'c')
     actual = abc
     assert expected == actual
+
+
+x, y, z = lambda_fixture('a', 'b', 'c')
+
+
+def it_processes_toplevel_destructured_tuple_lambda_fixture(x, y, z):
+    expected = ('a', 'b', 'c')
+    actual = (x, y, z)
+    assert expected == actual
+
+
+pa, pb, pc, pd = lambda_fixture(params=[
+    pytest.param('alfalfa', 'better', 'dolt', 'gamer'),
+])
+
+
+def it_processes_toplevel_destructured_parametrized_lambda_fixture(pa, pb, pc, pd):
+    expected = ('alfalfa', 'better', 'dolt', 'gamer')
+    actual = (pa, pb, pc, pd)
+    assert expected == actual
+
+
+destructured_id = lambda_fixture(params=[
+    pytest.param('muffin', id='muffin'),
+])
+
+
+def it_uses_ids_from_destructured_parametrized_lambda_fixture(destructured_id, request):
+    assert destructured_id in request.node.callspec.id
 
 
 class TestClass:


### PR DESCRIPTION
# Brief

This PR adds support for the easy case and the useful case of lambda fixture destructuring:
 - The easy case — lambda fixtures that reference multiple other fixtures:
	  ```py
	  a = static_fixture('a')
	  b = static_fixture('b')
	  c = static_fixture('c')
	  x, y, z = lambda_fixture('a', 'b', 'c')
	  ```
 - The useful case — parametrized lambda fixtures:
	  ```py
	  pa, pb, pc, pd = lambda_fixture(params=[
	       pytest.param('alfalfa', 'better', 'dolt', 'gamer'),
	  ])


	  def it_processes_toplevel_destructured_parametrized_lambda_fixture(pa, pb, pc, pd):
	      expected = ('alfalfa', 'better', 'dolt', 'gamer')
	      actual = (pa, pb, pc, pd)
	      assert expected == actual
	```